### PR TITLE
Redesign homepage with creamy paper aesthetic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,8 @@ To add a report or artifact:
 3. For artifacts: also add OG/Twitter meta + JSON-LD with absolute `https://adumb.dev/...` URLs, and an OG image (1200×630, can be SVG)
 4. Commit and push
 
-### Nav grid is hardcoded
-`style.css` uses `grid-template-columns: repeat(N, 1fr)` for the homepage nav — `N` is the literal link count. If you add or remove a nav item, update the column count too.
+### Homepage nav is flex chips
+`style.css` lays out the homepage nav as a flex-wrap row of pill-shaped `.chip` links — adding or removing a chip needs no layout changes, they wrap on their own.
 
 ## Git
 

--- a/index.html
+++ b/index.html
@@ -6,47 +6,60 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Adam Sisk</title>
-  <link rel="icon"
-    href="https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/120/apple/198/male-technologist_1f468-200d-1f4bb.png">
-  <link href="https://fonts.googleapis.com/css?family=Montserrat:200,400,800&display=swap" rel="stylesheet">
+  <meta name="description" content="Adam Sisk — software engineer at Ramsey Solutions.">
+  <link rel="icon" href="./favicon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./style.css">
-
 </head>
 
 <body>
-  <div class="landing">
+  <svg class="grain" aria-hidden="true" focusable="false">
+    <filter id="grain">
+      <feTurbulence type="fractalNoise" baseFrequency="0.85" numOctaves="2" stitchTiles="stitch" />
+      <feColorMatrix values="0 0 0 0 0
+                             0 0 0 0 0
+                             0 0 0 0 0
+                             0 0 0 0.09 0" />
+    </filter>
+    <rect width="100%" height="100%" filter="url(#grain)" />
+  </svg>
 
-    <header class="header">
-      <h1 class="title"><span>hi my name is </span><strong>Adam Sisk</strong></h1>
-      <!-- <div class="desc"> -->
-      <p class="desc">I'm a Software Engineer at <a href="https://www.ramseyinhouse.com/">Ramsey Solutions</a></p>
-      <!-- <p class="">These are some little things I've learned</p> -->
-      <!-- </div> -->
+  <main class="page">
+    <header class="brand">
+      <span class="brand__dot" aria-hidden="true"></span>
+      <span class="brand__name">adumb.dev</span>
     </header>
-    <nav class="nav">
-      <ul class="list">
-        <li class="link"><a href="mailto:adamsisk91@gmail.com?subject=Hi%20Adam">say hi</a></li>
-        <li class="link"><a href="./assets/ADAMSISKRESUME.pdf">resume</a></li>
-        <li class="link icon"><a href="https://www.linkedin.com/in/adamsisk/">LinkedIn</a></li>
-        <li class="link icon"><a href="https://github.com/CalamityAdam/flts-frontend">GitHub</a></li>
-      </ul>
-    </nav>
-    <div class="about">
-      <img 
-        src="./assets/adam-headshot.jpg"
-        width=600
-        height=auto
-        alt="adam sisk"
-      >
-    </div>
-  </div>
-  <div class="skills">
-    
-  </div>
-  
-  <style>
-    
-  </style>
+
+    <section class="intro">
+      <p class="intro__hello">hi —</p>
+      <h1 class="intro__name">I'm <span class="intro__hl">Adam&nbsp;Sisk</span>.</h1>
+      <p class="intro__lede">
+        A software engineer at
+        <a href="https://www.ramseyinhouse.com/">Ramsey Solutions</a>,
+        mostly writing TypeScript and the occasional write-up.
+      </p>
+
+      <nav class="links" aria-label="Primary">
+        <a class="chip" href="mailto:adamsisk91@gmail.com?subject=Hi%20Adam">say hi</a>
+        <a class="chip" href="./assets/ADAMSISKRESUME.pdf">resume</a>
+        <a class="chip" href="https://www.linkedin.com/in/adamsisk/">linkedin</a>
+        <a class="chip" href="https://github.com/CalamityAdam">github</a>
+      </nav>
+    </section>
+
+    <figure class="portrait">
+      <div class="portrait__frame">
+        <img src="./assets/adam-headshot.jpg" alt="Adam Sisk" width="600" height="600" loading="eager" decoding="async">
+      </div>
+    </figure>
+
+    <footer class="foot">
+      <span class="foot__line">made by hand · <a href="https://github.com/CalamityAdam/calamityAdam.github.io">view source</a></span>
+    </footer>
+  </main>
+
   <script src="./index.js"></script>
 </body>
 

--- a/style.css
+++ b/style.css
@@ -1,208 +1,318 @@
+/* ---- Animatable custom properties (used for the slow conic accent) ---- */
+@property --hue {
+  syntax: "<angle>";
+  inherits: false;
+  initial-value: 0deg;
+}
+
 :root {
-  /* variables */
-  --black: #35393c;
-  --teal: #42858c;
-  --pastel: #b5d5d0;
-  --red: #db3a34;
-  --green: #397367;
-  --blue: #1D70A2;
+  --cream:     #f6efe1;
+  --cream-2:   #ece1cb;
+  --ink:       #2a2620;
+  --ink-soft:  #5b5247;
+  --peach:     #f1b89e;
+  --sage:      #c2cdac;
+  --rose:      #d8a39c;
+
+  --line:      color-mix(in srgb, var(--ink) 18%, transparent);
+  --line-bold: color-mix(in srgb, var(--ink) 32%, transparent);
 }
 
-html {
-  font-size: 20px;
-  box-sizing: border-box;
-  color: var(--black);
-}
+*, *::before, *::after { box-sizing: border-box; }
+* { margin: 0; padding: 0; }
 
-a {
-  color: var(--black);
-}
+html { color-scheme: light; }
 
-*,
-*:before,
-*:after {
-  box-sizing: inherit;
-}
-
-* {
-  margin: 0;
-  padding: 0;
-}
 body {
-  font-family: 'Montserrat', sans-serif;
-  font-size: 20px;
-  background-color: var(--pastel);
-  color: var(--black);
-  justify-content: center;
-  align-items: center;
-  /* margin: 1rem; */
-  /* min-height: calc(100vh - 100px); */
+  font-family: 'Montserrat', system-ui, -apple-system, sans-serif;
+  font-size: clamp(15px, 0.5vw + 13.5px, 17.5px);
+  line-height: 1.5;
+  color: var(--ink);
+  background: var(--cream);
+  min-height: 100svh;
+  position: relative;
+  overflow-x: hidden;
 }
 
-.landing {
-  height: 100vh;
+/* Soft warm wash so the page doesn't look flat — two large radial gradients
+   in derived tints. Sits below the grain overlay. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(60vmax 50vmax at 12% 18%, color-mix(in srgb, var(--peach) 22%, transparent), transparent 60%),
+    radial-gradient(55vmax 45vmax at 88% 90%, color-mix(in srgb, var(--sage) 24%, transparent), transparent 60%);
+}
+
+a { color: var(--ink); }
+
+/* ---- Paper grain ---- */
+.grain {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+  opacity: 0.55;
+  z-index: 50;
+}
+
+/* ---- Layout ---- */
+.page {
+  --pad: clamp(1.25rem, 4vw, 2.75rem);
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--pad);
+  min-height: 100svh;
   display: grid;
-  gap: 1rem;
-  grid-template-rows: 1fr 50px 5fr;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  grid-template-rows: auto 1fr auto;
   grid-template-areas:
-    ". title ."
-    ". links ."
-    ". about .";
-  /* grid-template-columns: auto; */
-}
-
-.header {
-  display: grid;
-  gap: 0.5rem;
-  grid-template-rows: 100px 50px;
+    "brand    portrait"
+    "intro    portrait"
+    "foot     foot";
+  column-gap: clamp(1.5rem, 4vw, 3.5rem);
+  row-gap: clamp(1.5rem, 3vw, 2.5rem);
   align-items: center;
-  justify-content: center;
-  grid-column: 2 / 3;
-  /* margin: 0.5rem; */
 }
 
-
-.header strong {
-  margin-left: 0.75rem;
-  display: inline-block;
-}
-
-.header span {
-  display: inline-block;
-}
-
-.header .title {
-  border: 2px solid var(--blue);
-  padding: 0.5rem;
-  border-radius: 5px;
-  font-weight: 400;
-  color: var(--black);
-  text-transform: uppercase;
-  grid-template-rows: 1fr 1fr;
-  gap: 0.5rem;
-}
-
-.header .desc {
-  justify-content: center;
-  text-align: center;
-  align-items: center;
-  /* border-bottom: 2px solid var(--red); */
-}
-
-.nav {
-  grid-area: links;
-}
-
-.list {
-  justify-content: center;
-  align-items: center;
-  display: grid;
-  grid-template-columns:repeat(4, 1fr);
-  /* gap: 20px; */
-  grid-column: 2 / 3;
-}
-
-.list .link {
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-}
-
-.item {
-  display: grid;
-  justify-content: center;
-  align-items: center;
-  border: 5px solid var(--black);
-  border-radius: 3px;
-}
-
-.nav ul {
-  list-style-type: none;
-}
-
-.nav li {
-  display: inline-block;
-}
-
-.nav a {
-  color: var(--blue);
-  text-decoration: underline;
-  text-transform: uppercase;
-}
-
-.about {
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  grid-area: about;
-}
-
-.about img {
-  border-radius: 50%;
-  transition: all 0.4s;
-  /* transition-timing-function: cubic-bezier(0.65, 0.05, 0.54, 1.4); */
-}
-
-/* .about img:hover {
-  border-radius: 8px;
-} */
-
-@media (max-width: 600px) {
-  .landing {
-    grid-template-rows: 2fr 10fr 1fr;
+@media (max-width: 760px) {
+  .page {
     grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto auto;
     grid-template-areas:
-    "title"
-    "about"
-    "links";
-  }
-  .header {
-    justify-items: center;
-    align-items: center;
-    text-align: center;
-    grid-column: 1;
-    margin: 2rem;
-  }
-  
-  .header strong {
-    margin-left: 0;
-  }
-  .header span {
-    /* margin-left: 10px; */
-  }
-  .header .desc {
-    /* margin-left: 10px; */
-  }
-  .about img {
-    width: 300px;
-    margin: 1rem;
-  }
-  .nav {
-    /* bottom: 0; */
-    margin: 0 1rem;
-    align-items: center;
-    align-content: center;
-    vertical-align: middle;
-  }
-  .nav .list {
-    grid-column: auto;
+      "brand"
+      "portrait"
+      "intro"
+      "foot";
+    align-items: start;
+    row-gap: 1.75rem;
   }
 }
 
-
-
-
-
-
-
-
-
-
-.item {
-  display: grid;
-  justify-content: center;
+/* ---- Brand mark (top-left) ---- */
+.brand {
+  grid-area: brand;
+  display: inline-flex;
   align-items: center;
-  border: 5px solid var(--black);
-  border-radius: 3px;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-soft);
+  align-self: start;
+}
+.brand__dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--peach);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--peach) 28%, transparent);
+  animation: brand-pulse 3.4s ease-in-out infinite;
+}
+@keyframes brand-pulse {
+  0%, 100% { transform: scale(1); }
+  50%      { transform: scale(1.18); }
+}
+
+/* ---- Intro copy ---- */
+.intro {
+  grid-area: intro;
+  max-width: 36ch;
+  align-self: center;
+}
+.intro__hello {
+  font-style: italic;
+  font-weight: 300;
+  font-size: 1.1rem;
+  color: var(--ink-soft);
+  margin-bottom: 0.25rem;
+}
+.intro__name {
+  font-weight: 300;
+  font-size: clamp(2.6rem, 5.5vw + 1rem, 4.6rem);
+  line-height: 1.04;
+  letter-spacing: -0.022em;
+  margin-bottom: 1.2rem;
+  text-wrap: balance;
+}
+/* Marker-style highlight under the name. Pure CSS — gradient stops in
+   percentages give it a faintly off-baseline look. */
+.intro__hl {
+  font-weight: 900;
+  background-image: linear-gradient(
+    180deg,
+    transparent 72%,
+    color-mix(in srgb, var(--peach) 78%, transparent) 72%,
+    color-mix(in srgb, var(--peach) 78%, transparent) 92%,
+    transparent 92%
+  );
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  padding: 0 0.08em;
+}
+.intro__lede {
+  font-size: 1.02rem;
+  color: var(--ink-soft);
+  text-wrap: pretty;
+  max-width: 32ch;
+}
+.intro__lede a {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--peach) 70%, transparent);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.2s ease;
+}
+.intro__lede a:hover { text-decoration-color: var(--peach); }
+
+/* ---- Nav chips ---- */
+.links {
+  margin-top: 1.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.chip {
+  --chip-bg: color-mix(in srgb, var(--cream-2) 75%, transparent);
+  font-family: inherit;
+  font-size: 0.92rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--chip-bg);
+  color: var(--ink);
+  text-decoration: none;
+  transition:
+    transform 0.18s ease,
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+.chip:hover {
+  --chip-bg: color-mix(in srgb, var(--peach) 32%, var(--cream));
+  border-color: var(--line-bold);
+  transform: translateY(-2px) rotate(-0.6deg);
+}
+.chip:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ink) 55%, transparent);
+  outline-offset: 3px;
+}
+
+/* ---- Portrait ----
+   The frame is the photo. ::before is the offset peach card behind it.
+   ::after is a thin conic gradient ring drawn with mask-composite, slowly
+   rotated via the registered --hue property. */
+.portrait {
+  grid-area: portrait;
+  justify-self: center;
+  width: min(420px, 78vw);
+  aspect-ratio: 1;
+  position: relative;
+  isolation: isolate;
+}
+
+.portrait::before {
+  content: "";
+  position: absolute;
+  inset: -14px -14px 14px 14px;
+  border-radius: 22px;
+  background: var(--peach);
+  transform: rotate(-2.5deg);
+  transition: transform 0.55s ease, background-color 0.55s ease;
+  z-index: 0;
+}
+
+.portrait::after {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 24px;
+  padding: 2px;
+  background: conic-gradient(
+    from var(--hue),
+    var(--peach),
+    var(--sage),
+    var(--rose),
+    var(--peach)
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  opacity: 0.55;
+  animation: portrait-spin 32s linear infinite;
+  z-index: 2;
+  pointer-events: none;
+}
+@keyframes portrait-spin {
+  to { --hue: 360deg; }
+}
+
+.portrait__frame {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  border-radius: 20px;
+  overflow: hidden;
+  background: var(--cream-2);
+  box-shadow:
+    0 1px 2px rgba(42, 38, 32, 0.06),
+    0 14px 32px -16px rgba(42, 38, 32, 0.28);
+}
+.portrait__frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.92) contrast(0.97);
+  transition: filter 0.6s ease, transform 0.7s ease;
+}
+
+/* Hover: the offset card straightens, photo warms up slightly. */
+.portrait:hover .portrait__frame img {
+  filter: saturate(1.05) contrast(1);
+  transform: scale(1.015);
+}
+.portrait:hover::before {
+  transform: rotate(-0.4deg);
+  background-color: color-mix(in srgb, var(--peach) 88%, var(--rose));
+}
+
+/* :has() — when any chip is being hovered, give the offset card a tiny
+   responsive nudge. Subtle parent-selector demo. */
+.page:has(.chip:hover) .portrait::before {
+  transform: rotate(-3.5deg) translate(-2px, 2px);
+}
+
+/* ---- Footer ---- */
+.foot {
+  grid-area: foot;
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-soft);
+  align-self: end;
+}
+.foot a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--line);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.2s ease;
+}
+.foot a:hover { text-decoration-color: var(--line-bold); }
+
+/* ---- Reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
 }


### PR DESCRIPTION
## Summary

Full reshape of the landing page — moving away from the teal/pastel-blue palette toward a softer cream/peach/sage paper aesthetic. Layout becomes an asymmetric two-column on desktop (intro left, headshot right) and stacks cleanly on mobile.

A few small, deliberate CSS demos sprinkled in (kept subtle so the page reads as handcrafted, not over-styled):

- **`@property` registered custom prop** drives the slow conic accent ring around the portrait — required for animating a gradient angle smoothly.
- **`color-mix()`** for derived chip hover backgrounds, underline tints, and faint border lines, all from a small palette of named tokens.
- **`text-wrap: balance` / `pretty`** on the heading + lede.
- **`clamp()`** fluid type for the body and the name.
- **`:has()` parent selector** so the offset peach card behind the headshot nudges when a nav chip is hovered.
- **SVG `feTurbulence`** noise overlay for paper grain (low-opacity, multiply blend).
- **conic-gradient + `mask-composite: exclude`** for the thin gradient ring (no extra elements needed).
- `prefers-reduced-motion` honored.

The rigid `repeat(N, 1fr)` nav grid is gone — replaced with flex-wrap `.chip` links so adding/removing entries is layout-free. CLAUDE.md updated to reflect that.

Also fixed: favicon now points at the local `favicon.svg` (was a hotlinked emojipedia PNG) and the GitHub nav link points at the profile rather than a single repo.

## Test plan

- [ ] Pages preview deploy renders the new layout at desktop and mobile widths
- [ ] Headshot conic ring rotates smoothly (Chromium/Safari)
- [ ] Hovering chips nudges the peach card behind the portrait (`:has()` reaction)
- [ ] `prefers-reduced-motion: reduce` halts the spin and pulse animations
- [ ] All four nav links resolve (mailto, resume PDF, LinkedIn, GitHub profile)

https://claude.ai/code/session_01XujkstwoaLjHtTrcopFULS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XujkstwoaLjHtTrcopFULS)_