### PR TITLE
Cut homepage copy ~75%, single-tagline headline, artifacts chip

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
 
         <nav class="links" aria-label="Primary">
           <a class="chip" href="mailto:adamsisk91@gmail.com?subject=Hi%20Adam">say hi</a>
+          <a class="chip" href="./artifacts/">artifacts</a>
           <a class="chip" href="https://github.com/CalamityAdam">github</a>
         </nav>
       </div>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Adam Sisk</title>
-  <meta name="description" content="Adam Sisk, software engineer at Ramsey Solutions.">
+  <meta name="description" content="Adam Sisk. I make things on the internet.">
   <link rel="icon" href="./favicon.svg" type="image/svg+xml">
 
   <link rel="preload" as="image"
@@ -35,13 +35,7 @@
   <main class="page">
     <section class="hero">
       <div class="intro">
-        <p class="hello">hi.</p>
-        <h1 class="name">I'm <strong>Adam Sisk</strong>.</h1>
-        <p class="lede">
-          Software engineer at
-          <a href="https://www.ramseyinhouse.com/">Ramsey Solutions</a>.
-          Mostly TypeScript and Java, with the occasional note or report.
-        </p>
+        <h1 class="name">hi i'm <strong>adam sisk</strong> i make things on the internet</h1>
 
         <nav class="links" aria-label="Primary">
           <a class="chip" href="mailto:adamsisk91@gmail.com?subject=Hi%20Adam">say hi</a>
@@ -64,20 +58,6 @@
             loading="eager" decoding="async" fetchpriority="high">
         </picture>
       </div>
-    </section>
-
-    <section class="about" aria-labelledby="about-h">
-      <h2 id="about-h" class="about__h">about</h2>
-      <p>
-        I'm on the internal engineering team at
-        <a href="https://www.ramseyinhouse.com/">Ramsey</a>.
-        I keep notes when something is worth keeping notes on.
-      </p>
-      <p>
-        Want to talk shop or just say hi?
-        <a href="mailto:adamsisk91@gmail.com?subject=Hi%20Adam">Email is the fastest way</a>,
-        or grab my <a href="./assets/ADAMSISKRESUME.pdf">resume</a>.
-      </p>
     </section>
   </main>
 

--- a/style.css
+++ b/style.css
@@ -78,7 +78,7 @@ a { color: inherit; }
   .portrait { order: 0; }
 }
 
-.intro { max-width: 28ch; }
+.intro { max-width: 32em; }
 
 .name {
   font-weight: 600;
@@ -90,6 +90,7 @@ a { color: inherit; }
 }
 .name strong {
   font-weight: 800;
+  white-space: nowrap;
   background-image: linear-gradient(
     transparent 68%,
     color-mix(in srgb, var(--peach) 65%, transparent) 68%,

--- a/style.css
+++ b/style.css
@@ -78,22 +78,14 @@ a { color: inherit; }
   .portrait { order: 0; }
 }
 
-.intro { max-width: 36ch; }
-
-.hello {
-  font-style: italic;
-  font-weight: 500;
-  font-size: 1.05rem;
-  color: var(--ink-soft);
-  margin-bottom: 0.4rem;
-}
+.intro { max-width: 28ch; }
 
 .name {
   font-weight: 600;
-  font-size: clamp(2.4rem, 5vw + 0.9rem, 4.4rem);
-  line-height: 1.04;
+  font-size: clamp(1.85rem, 2.2vw + 1.05rem, 2.85rem);
+  line-height: 1.18;
   letter-spacing: -0.012em;
-  margin-bottom: 1.1rem;
+  margin-bottom: 1.4rem;
   text-wrap: balance;
 }
 .name strong {
@@ -108,22 +100,6 @@ a { color: inherit; }
   background-size: 100% 100%;
   padding: 0 0.06em;
 }
-
-.lede {
-  font-size: 1.02rem;
-  text-wrap: pretty;
-  max-width: 32ch;
-}
-.lede a,
-.about a {
-  text-decoration: underline;
-  text-decoration-color: color-mix(in srgb, var(--peach-deep) 60%, transparent);
-  text-decoration-thickness: 2px;
-  text-underline-offset: 3px;
-  transition: text-decoration-color var(--dur-fast) var(--ease);
-}
-.lede a:hover,
-.about a:hover { text-decoration-color: var(--peach-deep); }
 
 /* ---- Nav chips ---- */
 .links {
@@ -209,23 +185,6 @@ a { color: inherit; }
   .portrait { width: min(260px, 30vw); }
   .portrait::before { inset: -8px -8px 8px 8px; }
 }
-
-/* ---- About ---- */
-.about {
-  max-width: 50ch;
-  margin: 0 auto;
-  display: grid;
-  gap: 0.85rem;
-}
-.about__h {
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--ink-soft);
-  margin-bottom: 0.25rem;
-}
-.about p { font-size: 1rem; }
 
 /* ---- Footer ---- */
 .foot {


### PR DESCRIPTION
## Summary

Heavy copy cut on the homepage. The old hero had three text elements (hello, name, lede) plus a two-paragraph about section. The new hero has one element: a single sentence-style headline. The about section is gone entirely, including the inline resume link.

### Headline

```
hi i'm adam sisk i make things on the internet
```

All lowercase. `<strong>adam sisk</strong>` keeps the peach highlight, so the headline reads as one casual sentence with the name as the visual anchor inside it.

### What was cut

| Element | Before | After |
|---|---|---|
| `.hello` | `hi.` | gone |
| `.name` | `I'm Adam Sisk.` | replaced with the new tagline |
| `.lede` | `Software engineer at Ramsey Solutions. Mostly TypeScript and Java, with the occasional note or report.` | gone |
| `.about` (h2 + 2 paragraphs) | `I'm on the internal engineering team at Ramsey...` plus contact CTA with inline resume link | gone |

Word count of visible copy: **63 to 15**. About a 76% reduction.

### Style adjustments

- `.name` retuned for the longer multi-line tagline: font-size clamp `2.4 to 4.4rem` is now `1.85 to 2.85rem`, line-height `1.04` is now `1.18`.
- `.intro` max-width `36ch` to `28ch` so the headline wraps to 2-3 lines on most viewports.
- Removed dead rules: `.hello`, `.lede`, `.lede a` / `.about a` shared link styling, `.about`, `.about__h`. About 30 lines of CSS gone.

### Artifacts chip

Per follow-up: added `<a class="chip" href="./artifacts/">artifacts</a>` to the hero nav between "say hi" and "github". The chip styling already exists, so this is one line of HTML. Order is action / content / meta.

### What remains visible

```
HEADLINE: hi i'm adam sisk i make things on the internet
CHIPS:    say hi · artifacts · github
PORTRAIT: (squircle headshot)
FOOTER:   view source
```

Three sentences worth of text, one image, one footer link. That's the whole page.

### Note on resume link

The inline resume link in the old about copy was removed in this cut. If you want it accessible from the homepage, easiest add is another chip (`<a class="chip" href="./assets/ADAMSISKRESUME.pdf">resume</a>`). Holding off until you say.

## Test plan

- [ ] Pages preview deploy renders the slim layout correctly at desktop, tablet, and mobile widths
- [ ] Headline wraps to 2-3 lines without overflow at all viewport widths
- [ ] Peach highlight under `adam sisk` stays visually grouped (browser may split the highlight if `text-wrap: balance` breaks between "adam" and "sisk" — acceptable, but verify)
- [ ] Three chips fit in one row on desktop and wrap cleanly on narrow phones
- [ ] `./artifacts/` chip routes to the artifacts index
- [ ] No layout shift between hero and footer (the page is now hero + footer with no middle content)

---
_Generated by [Claude Code](https://claude.ai/code/session_017iLAu3t36DLahvfgrDfYa2)_