### PR TITLE
Park view-source footer just below the fold

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,13 +48,15 @@ a { color: inherit; }
   z-index: 50;
 }
 
-/* Page shell */
+/* Page shell — fills the viewport so the footer sits just below the fold */
 .page {
   --pad: clamp(1.25rem, 4vw, 2.75rem);
   max-width: 1080px;
   margin: 0 auto;
   padding: var(--pad);
+  min-height: 100svh;
   display: grid;
+  align-content: center;
   gap: clamp(2.5rem, 6vw, 4.5rem);
 }
 


### PR DESCRIPTION
## Summary

One CSS change. `.page` gets `min-height: 100svh` and `align-content: center`. Net effect:

- The hero is vertically centered in the visible viewport on first paint (instead of sitting at the top of an oversized page).
- The `<footer class="foot">` lives outside `.page` in the DOM, so once `.page` fills 100svh, the footer naturally renders one footer-height (about 70px) below the fold. A small scroll reveals "view source" without it competing with the hero on first paint.

`100svh` (small viewport height) is used rather than `100vh` so iOS Safari's dynamic browser chrome does not push the footer into view on first paint.

`align-content: center` only kicks in when there is spare vertical room. On short landscape phones where the hero would be taller than the viewport, the page grows naturally and nothing clips.

## Diff

```css
.page {
  --pad: clamp(1.25rem, 4vw, 2.75rem);
  max-width: 1080px;
  margin: 0 auto;
  padding: var(--pad);
+ min-height: 100svh;
  display: grid;
+ align-content: center;
  gap: clamp(2.5rem, 6vw, 4.5rem);
}
```

## Test plan

- [ ] Desktop (1080px+ tall): hero is roughly vertically centered; footer is just below the fold; scrolling about 70px reveals "view source"
- [ ] iPhone Safari portrait: dynamic chrome (URL bar shrink/grow) does not pull the footer into view on first paint
- [ ] Short landscape phone: hero is not clipped; page scrolls naturally; footer follows below
- [ ] No regression on the squircle portrait sizing or the headline wrapping

---
_Generated by [Claude Code](https://claude.ai/code/session_017iLAu3t36DLahvfgrDfYa2)_