### PR TITLE
Actually park view-source below the fold on iOS Safari

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,13 +48,17 @@ a { color: inherit; }
   z-index: 50;
 }
 
-/* Page shell — fills the viewport so the footer sits just below the fold */
+/* Page shell — fills the viewport so the footer sits just below the fold.
+   100lvh (large viewport) is taller than 100svh on iOS Safari when the
+   URL bar is visible, so the page is provably taller than the visible
+   area. 100vh is the fallback for pre-iOS-15.4 browsers. */
 .page {
   --pad: clamp(1.25rem, 4vw, 2.75rem);
   max-width: 1080px;
   margin: 0 auto;
   padding: var(--pad);
-  min-height: 100svh;
+  min-height: 100vh;
+  min-height: 100lvh;
   display: grid;
   align-content: center;
   gap: clamp(2.5rem, 6vw, 4.5rem);
@@ -189,8 +193,12 @@ a { color: inherit; }
   .portrait::before { inset: -8px -8px 8px 8px; }
 }
 
-/* ---- Footer ---- */
+/* ---- Footer ----
+   margin-top adds an explicit gap between the page and the footer so the
+   footer is unambiguously below the fold even when 100lvh resolves close
+   to the visible viewport (e.g. desktop browsers, where lvh equals svh). */
 .foot {
+  margin-top: 6rem;
   text-align: center;
   font-size: 0.82rem;
   color: var(--ink-soft);


### PR DESCRIPTION
## Summary

Follow-up to #8. The previous fix used `.page { min-height: 100svh }`, but on iOS 17+ the floating bottom URL bar **overlays** the layout viewport rather than pushing it up. That makes `100svh` equal to the visible area when the URL bar is shown, so `.page` exactly fills the visible viewport and the footer sat right at the edge — which iOS scroll-anchoring sometimes pulls into first-paint view.

User reported: "i'm not seeing the view source link below the fold, it's snug up against the rest of the page" + screenshot of an iPhone with the footer visible mid-screen.

## Fix

Two changes:

1. **`.page` min-height switched from `100svh` to `100lvh`** with `100vh` as a fallback for older browsers. `lvh` is the largest viewport (URL bar collapsed). When the URL bar is visible (the common iOS Safari first-paint state), `100lvh` is taller than the visible area by the URL bar height (~80px), so `.page` extends past the fold.

2. **`.foot { margin-top: 6rem }`** added. Guarantees a real gap between page bottom and footer regardless of how the browser resolves viewport units. On desktop browsers (where `lvh` equals `svh` equals `vh`), the footer is still demonstrably below where page content ends.

```css
.page {
+ min-height: 100vh;       /* fallback */
+ min-height: 100lvh;      /* large viewport — taller than visible area when URL bar is shown */
- min-height: 100svh;
}

.foot {
+ margin-top: 6rem;
}
```

## Test plan

- [ ] iPhone Safari (URL bar visible, first paint): hero is centered, "view source" is **not** visible — small scroll reveals it
- [ ] iPhone Safari (URL bar collapsed after scroll): footer is at the very bottom of the document, requires scrolling to the end
- [ ] Desktop Chrome / Firefox at 1080px viewport: hero is centered, footer is ~6rem below the page bottom (about 96px), revealed by a small scroll
- [ ] Short landscape phone where hero is taller than viewport: page grows naturally, footer follows below content, no clipping
- [ ] No regression to portrait sizing, headline wrapping, or the artifacts chip

---
_Generated by [Claude Code](https://claude.ai/code/session_017iLAu3t36DLahvfgrDfYa2)_